### PR TITLE
Remove jsconfig to fix CRA test runner

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- remove `jsconfig.json` because Create React App fails when both `tsconfig.json` and `jsconfig.json` exist

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68823a28092c8324b82f871bf74f3027